### PR TITLE
Add landing page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,10 +7,10 @@ enableRobotsTXT: true
 
 menu:
   main:
-  - identifier: archive
-    name: Archive
-    title: Archive
-    url: /posts/
+  - identifier: about
+    name: About
+    title: About
+    url: /about/
     weight: 1
   - identifier: docs
     name: Docs 
@@ -20,6 +20,11 @@ menu:
     name: Releases
     url: https://mirror.openshift.com/pub/openshift-v4/clients/crc/
     weight: 3
+  - identifier: archive
+    name: Archive
+    title: Archive
+    url: /posts/
+    weight: 4
 
 params:
   author: "CRC Contributors"

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 languageCode: "en-US"
 baseUrl: "https://crc.dev/blog/"
-title: "Container Runtime Control"
+title: "CRC - Run OpenShift 4 on your laptop"
 theme: "anubis"
 paginate: 10
 enableRobotsTXT: true
@@ -22,7 +22,7 @@ menu:
     weight: 3
 
 params:
-  author: "Container Runtime Control Contributors"
+  author: "CRC Contributors"
   dateFormat: "2006-01-02"
   paginationSinglePost: true
   readMore: false

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,13 @@
+---
+title: "About"
+description: "CRC - Run OpenShift 4 on your laptop"
+date: "2022-04-20"
+author: "CRC Contributors"
+---
+CRC brings a minimal OpenShift Container Platform 4 cluster and Podman container runtime to your local computer. These runtimes provide minimal environments for development and testing purposes. CRC is mainly targeted at running on developers' desktops. For other OpenShift Container Platform use cases, such as headless or multi-developer setups, use the [full OpenShift installer](https://console.redhat.com/openshift/install).
+
+See the [OpenShift documentation](https://docs.openshift.com/container-platform/latest/welcome/index.html#developer-activities) for a full introduction to OpenShift Container Platform.
+
+CRC includes the crc command-line interface (CLI) to interact with the CRC instance using the desired container runtime.
+
+Learn more and contribute on [GitHub](https://github.com/code-ready/crc).

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,1 @@
+_index.md

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,22 @@
+{{ define "main" }}
+    <main aria-role="main">
+      <header class="homepage-header">
+        <h1>{{.Title}}</h1>
+        {{ with .Params.subtitle }}
+        <span class="subtitle">{{.}}</span>
+        {{ end }}
+      </header>
+      <div class="homepage-content">
+        <!-- Note that the content for index.html, as a sort of list page, will pull from content/_index.md -->
+        {{.Content}}
+      </div>
+      <h1>Recent blog posts</h1>
+      <div class="articles h-feed">
+        {{ $pages := where (where site.RegularPages "Type" "in" site.Params.mainSections) "Params.hidden" "!=" true }}
+        {{ range (.Paginate $pages).Pages }}
+            {{ partial "post-summary.html" . }}
+        {{ end }}
+        {{ partial "pagination.html" . }}
+      </div>
+    </main>
+{{ end }}


### PR DESCRIPTION
This adds a main page with a short description of what crc is (c&p'ed from crc's README.md on github).
With this change, we can move the content from crc.dev/blog to crc.dev, and point crc.dev/blog to the archive page