### PR TITLE
Update 'about' page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,10 +4,13 @@ description: "CRC - Run OpenShift 4 on your laptop"
 date: "2022-04-20"
 author: "CRC Contributors"
 ---
-CRC brings a minimal OpenShift Container Platform 4 cluster and Podman container runtime to your local computer. These runtimes provide minimal environments for development and testing purposes. CRC is mainly targeted at running on developers' desktops. For other OpenShift Container Platform use cases, such as headless or multi-developer setups, use the [full OpenShift installer](https://console.redhat.com/openshift/install).
+CRC brings a minimal OpenShift Container Platform 4 cluster or a MicroShift cluster to your local computer. These runtimes provide minimal environments for development and testing purposes. CRC is mainly targeted at running on developers' desktops. For other OpenShift Container Platform use cases, such as headless or multi-developer setups, use the [full OpenShift installer](https://console.redhat.com/openshift/install).
 
 See the [OpenShift documentation](https://docs.openshift.com/container-platform/latest/welcome/index.html#developer-activities) for a full introduction to OpenShift Container Platform.
 
-CRC includes the crc command-line interface (CLI) to interact with the CRC instance using the desired container runtime.
+CRC includes the `crc` command-line interface (CLI) to interact with the CRC instance using the desired container runtime.
+[podman-desktop](https://podman-desktop.io/) provides a graphical user interface for `crc` through its OpenShift Local extension.
+
+You can download Red Hat's builds of CRC as Red Hat OpenShift Local from https://console.redhat.com/openshift/create/local.
 
 Learn more and contribute on [GitHub](https://github.com/crc-org/crc).


### PR DESCRIPTION
Now that this blog is the landing page for crc.dev, let's add a link to
the download page, and reference the microshift bundle instead of the
podman one.

However I think this text was a copy of https://github.com/crc-org/crc/blob/main/docs/modules/getting_started/partials/con_about.adoc
maybe better to first update crc's doc.